### PR TITLE
ci: dependabot + auto-merge de parches/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 5
+    groups:
+      dependencias-menores:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Sub-proyecto anidado con su propio package.json
+  - package-ecosystem: "npm"
+    directory: "/Prototip/prototip-web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps(prototip-web)"
+    open-pull-requests-limit: 5
+    groups:
+      dependencias-menores:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: "Dependabot auto-merge"
+
+# Aviso: este repo no tiene workflow de CI/tests todavía, así que el
+# auto-merge no espera ninguna comprobación antes de fusionar un PR de
+# parche/minor. Añadir un workflow de test aquí es lo que le daría un
+# freno real a esto.
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Leer metadatos del PR de Dependabot
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-aprobar y activar auto-merge (squash)
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --squash --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Añade dependabot.yml (npm, cubriendo raíz y /Prototip/prototip-web) y un workflow que aprueba y fusiona automáticamente los PRs de Dependabot que sean parche/minor, cuando pasen los checks. Los major se quedan para revisión manual.

Nota: este repo no tiene CI/tests todavía, así que por ahora el auto-merge no espera ninguna comprobación.